### PR TITLE
Enhancements to the repository configuration logic

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 PowerDNS.COM BV
+Copyright (c) 2019 PowerDNS.COM BV
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -15,24 +15,15 @@ Available variables are listed below, along with default values (see defaults/ma
 
     metronome_install_repo: "{{ metronome_powerdns_repo_master }}"
 
-By default Metronome is installed from the master repository.
-To install Metronome from a custom repository, override the `metronome_install_repo` default value in your playbook
-as shown below
+By default Metronome is installed from the repositories available on the host.
 
-    - hosts: all
-      vars:
-        metronome_install_repo:
-          apt_repo: "deb http://my.repo.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}/metronome main"
-          gpg_key: "http://my.repo.com/MYREPOGPGPUBKEY.asc" # repository's public GPG key
-          gpg_key_id: "MYREPOGPGPUBKEYID"                   # to avoid to reimport the key each time the role is executed
-          yum_repo_baseurl: "http://my.repo.com/centos/$basearch/$releasever/metronome"
-          yum_repo_name: "metronome"
-      roles:
-        - { role: PowerDNS.metronome }
+    metronome_install_repo: "{{ metronome_powerdns_repo_master }}"
 
-If `metronome_configure_repo` is True, the role will add the metronome repository to the system.
-The `metronome_apt_repo` and `metronome_yum_repo` variables should contain the URL of the repository according to the target operating system.
-The specification of the GPG key through the `metronome_gpg_key_url` and `metronome_gpg_key_id` variables, although recommended, is not mandatory.
+Master build of Metronome can be installed setting the `metronome_install_repo` variable as shown above.
+
+    metronome_install_debug_symbols_package: False
+
+Install Metronome symbols package
 
     metronome_user: "metronome"
     metronome_group: "metronome"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
-# By default Metronome is installed from the master repository.
-metronome_install_repo: "{{ metronome_powerdns_repo_master }}"
+# By default Metronome installed from the repositories configured on the host.
+metronome_install_repo: ""
 
 # To install Metronome from a custom repository
 # override the `metronome_install_repo` default value in your playbook.
@@ -9,13 +9,17 @@ metronome_install_repo: "{{ metronome_powerdns_repo_master }}"
 # - hosts: all
 #   vars:
 #     metronome_install_repo:
-#       apt_repo: "deb http://my.repo.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}/metronome main"
-#       gpg_key: "http://my.repo.com/MYREPOGPGPUBKEY.asc" # repository's public GPG key
+#       apt_repo: "deb http://repo.example.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}/metronome main"
+#       gpg_key: "http://repo.example.com/MYREPOGPGPUBKEY.asc" # repository's public GPG key
 #       gpg_key_id: "MYREPOGPGPUBKEYID"                   # to avoid to reimport the key each time the role is executed
-#       yum_repo_baseurl: "http://my.repo.com/centos/$basearch/$releasever/metronome"
-#       yum_repo_name: "metronome"
+#       yum_repo_baseurl: "http://repo.example.com/centos/$basearch/$releasever/metronome"
+#       yum_debug_symbols_repo_baseurl: "http://repo.example.com/centos/$basearch/$releasever/metronome/debug"
+#       name: "metronome"
 #   roles:
 #    - { role: PowerDNS.metronome }
+
+# Install Metronome symbols package
+metronome_install_debug_symbols_package: False
 
 # The user and group running the metronome service.
 # NOTE: This role does not create any user as we assume the user and group
@@ -34,7 +38,7 @@ metronome_webserver_address: "[::]:8000"
 # The directory in which metronome will store the collected stats files.
 metronome_stats_directory: '/var/lib/metronome'
 
-# If metronome_replace_local_js is set to True, 
+# If metronome_replace_local_js is set to True,
 # the role will override the default metronome local.js in order to make
 # the metronome UI connect to the metronome instance available at metronome_local_js_address
 # via metronome_local_js_scheme.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,9 +2,9 @@
 
 - name: restart metronome
   service:
-    name=metronome
-    state=restarted
+    name: metronome
+    state: restarted
 
-- name: systemctl daemon-reload (metronome)
+- name: reload systemd and restart metronome
   command: systemctl daemon-reload
   notify: restart metronome

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -15,9 +15,7 @@
     template:
       src: metronome.service.j2
       dest: /etc/systemd/system/metronome.service.d/override.conf
-    notify:
-      - systemctl daemon-reload (metronome)
-      - restart metronome
+    notify: reload systemd and restart metronome
 
   when: ansible_service_mgr == "systemd"
 
@@ -27,8 +25,7 @@
     template:
       src: metronome.default.j2
       dest: /etc/default/metronome
-    notify:
-      - restart metronome
+    notify: restart metronome
 
   when: ansible_service_mgr != "systemd"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Include OS-specific variables
+  include_vars: "{{ ansible_os_family }}.yml"
+  tags:
+    - always
+
 ###
 # Metronome Repository
 ###
@@ -18,6 +23,14 @@
   package:
     name: metronome
     state: present
+  tags:
+    - install
+
+- name: Install Metronome debug symbols
+  package:
+    name: "{{ _metronome_debug_symbols_package_name }}"
+    state: present
+  when: metronome_install_debug_symbols_package
   tags:
     - install
 

--- a/tasks/repo-Debian.yml
+++ b/tasks/repo-Debian.yml
@@ -1,14 +1,26 @@
 ---
 
-- name: Import the metronome APT repository key
+- name: Install gnupg
+  package:
+    name: gnupg
+    state: present
+
+- name: Import the Metronome APT repository key
   apt_key:
     url: "{{ metronome_install_repo['gpg_key'] }}"
     id: "{{ metronome_install_repo['gpg_key_id'] | default('') }}"
     state: present
+  register: _metronome_apt_key
   when: "'gpg_key' in metronome_install_repo and metronome_install_repo['gpg_key'] != ''"
 
 - name: Add the metronome APT repository
   apt_repository:
+    filename: "{{ metronome_install_repo['name'] }}"
     repo: "{{ metronome_install_repo['apt_repo'] }}"
     state: present
+  register: _metronome_apt_repo
 
+- name: Update the APT cache
+  apt:
+    update_cache: yes
+  when: "_metronome_apt_key.changed or _metronome_apt_repo.changed"

--- a/tasks/repo-RedHat.yml
+++ b/tasks/repo-RedHat.yml
@@ -4,13 +4,27 @@
   package:
     name: yum-plugin-priorities
     state: present
+  when: ansible_distribution in [ 'CentOS' ]
 
-- name: Add the metronome YUM repository
+- name: Add the Metronome YUM repository
   yum_repository:
-    name: "{{ metronome_install_repo['yum_repo_name'] }}"
-    description: PowerDNS Metronome Repository
+    name: "{{ metronome_install_repo['name'] }}"
+    file: "{{ pdns_rec_install_repo['name'] }}"
+    description: PowerDNS Metronome
     baseurl: "{{ metronome_install_repo['yum_repo_baseurl'] }}"
     gpgkey: "{{ metronome_install_repo['gpg_key'] }}"
     gpgcheck: "{{ metronome_install_repo['gpg_key'] != '' }}"
     priority: 90
     state: present
+
+- name: Add the Metronome debug symbols YUM repository
+  yum_repository:
+    name: "{{ metronome_install_repo['name'] }}-debuginfo"
+    file: "{{ pdns_rec_install_repo['name'] }}"
+    description: PowerDNS Metronome - debug symbols
+    baseurl: "{{ metronome_install_repo['yum_repo_baseurl'] }}"
+    gpgkey: "{{ metronome_install_repo['gpg_key'] }}"
+    gpgcheck: "{{ metronome_install_repo['gpg_key'] != '' }}"
+    priority: 90
+    state: present
+  when: metronome_install_debug_symbols_package

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,3 @@
+---
+
+_metronome_debug_symbols_package_name: "metronome-dbg"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,3 @@
+---
+
+_metronome_debug_symbols_package_name: "metronome-debuginfo"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,4 +5,5 @@ metronome_powerdns_repo_master:
   gpg_key: "http://repo.powerdns.com/CBC8B383-pub.asc"
   gpg_key_id: "D47975F8DAE32700A563E64FFF389421CBC8B383"
   yum_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/metronome-master"
-  yum_repo_name: "metronome"
+  yum_debug_symbols_repo_baseurl: "http://repo.powerdns.com/centos/$basearch/$releasever/metronome-master/debug"
+  name: "metronome-master"


### PR DESCRIPTION
This PR implements the following enhancements to the logic to configure the Metronome software repository in the role:
- the YUM and APT repositories are not configured in a specific file
- by default, no repository is configured by the role. To install metronome from the master PowerDNS build the `metronome_install_repo: "{{ metronome_powerdns_repo_master }}"` should be set
- the possibility to install debug symbols packages have been added through the `metronome_install_debug_symbols_package` variable